### PR TITLE
Wrap attachment_response with list

### DIFF
--- a/claude-api/claude_api.py
+++ b/claude-api/claude_api.py
@@ -76,16 +76,13 @@ class Client:
     url = "https://claude.ai/api/append_message"
 
     # Upload attachment if provided
-    attachments = []
     if attachment:
       attachment_response = self.upload_attachment(attachment)
       if attachment_response:
-        attachments = attachment_response
+        attachments = [attachment_response]
       else:
         return {"Error: Invalid file format. Please try again."}
-
-    # Ensure attachments is an empty list when no attachment is provided
-    if not attachment:
+    else:
       attachments = []
 
     payload = json.dumps({


### PR DESCRIPTION
The `attachments` field expects a list of attachments but `attachment_response` is only a dict