### PR TITLE
Add multiple attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,15 @@ To send a message to Claude, you can use the send_message method. You need to pr
     response = claude_api.send_message(prompt, conversation_id)
     print(response)
 
-## Send Message with attachment
+## Send Message with Attachments
 
-You can send any type of attachment to claude to get responses using attachment argument in send_message().
-Note: Claude currently supports only some file types.
+You can send multiple attachments (up to 5) to Claude to get responses using the `attachments` argument in `send_message()`. 
+Note: Make sure to provide a list of file paths even if you're sending just one file. Claude currently supports only certain file types.
 
-    prompt = "Hey,Summarize me this document.!"
+    prompt = "Hey, summarize the documents for me!"
     conversation_id = "<conversation_id>" or claude_api.create_new_chat()['uuid']
-    response = claude_api.send_message(prompt, conversation_id,attachment="path/to/file.pdf")
+    file_paths = ["path/to/file1.pdf", "path/to/file2.txt"]  # you can include up to 5 file paths in this list
+    response = claude_api.send_message(prompt, conversation_id, attachments=file_paths)
     print(response)
 
 

--- a/claude-api/claude_api.py
+++ b/claude-api/claude_api.py
@@ -72,21 +72,16 @@ class Client:
       print(f"Error: {response.status_code} - {response.text}")
 
   # Send Message to Claude
-  def send_message(self, prompt, conversation_id, attachment=None):
+  def send_message(self, prompt, conversation_id, attachments=[]):
     url = "https://claude.ai/api/append_message"
 
-    # Upload attachment if provided
-    attachments = []
-    if attachment:
+    uploaded_attachments = []
+    for attachment in attachments:
       attachment_response = self.upload_attachment(attachment)
       if attachment_response:
-        attachments = [attachment_response]
+        uploaded_attachments.append(attachment_response)
       else:
         return {"Error: Invalid file format. Please try again."}
-
-    # Ensure attachments is an empty list when no attachment is provided
-    if not attachment:
-      attachments = []
 
     payload = json.dumps({
       "completion": {
@@ -97,7 +92,7 @@ class Client:
       "organization_uuid": f"{self.organization_id}",
       "conversation_uuid": f"{conversation_id}",
       "text": f"{prompt}",
-      "attachments": attachments
+      "attachments": uploaded_attachments
     })
 
     headers = {


### PR DESCRIPTION
Refactored `send_message` to support multiple attachments (up to 5) per request. Updated README for clarity.

