### PR TITLE
add: proxies argument for Client class initializing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,5 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+

--- a/claude-api/claude_api.py
+++ b/claude-api/claude_api.py
@@ -1,15 +1,21 @@
 import json
 import os
-import uuid
-from curl_cffi import requests
-import requests as req
 import re
+import uuid
+
+import requests as req
+from curl_cffi import requests
 
 
 class Client:
 
-  def __init__(self, cookie):
+  def __init__(self, cookie, proxies=None):
+    """
+    :param cookie: cookie for Claude.ai
+    :param proxies: proxies for requests, e.g. {"http": "http://localhost:3450", "https": "http://localhost:3450"}
+    """
     self.cookie = cookie
+    self.proxies = proxies
     self.organization_id = self.get_organization_id()
 
   def get_organization_id(self):
@@ -28,7 +34,7 @@ class Client:
         'Cookie': f'{self.cookie}'
     }
 
-    response = requests.get(url, headers=headers,impersonate="chrome110")
+    response = requests.get(url, headers=headers,impersonate="chrome110", proxies=self.proxies)
     res = json.loads(response.text)
     uuid = res[0]['uuid']
 
@@ -64,7 +70,7 @@ class Client:
         'Cookie': f'{self.cookie}'
     }
 
-    response = requests.get(url, headers=headers,impersonate="chrome110")
+    response = requests.get(url, headers=headers,impersonate="chrome110", proxies=self.proxies)
     conversations = response.json()
 
     # Returns all conversation information in a list
@@ -119,7 +125,7 @@ class Client:
       'TE': 'trailers'
     }
 
-    response = requests.post( url, headers=headers, data=payload,impersonate="chrome110",timeout=500)
+    response = requests.post( url, headers=headers, data=payload,impersonate="chrome110",timeout=500, proxies=self.proxies)
     decoded_data = response.content.decode("utf-8")
     decoded_data = re.sub('\n+', '\n', decoded_data).strip()
     data_strings = decoded_data.split('\n')
@@ -156,7 +162,7 @@ class Client:
         'TE': 'trailers'
     }
 
-    response = requests.delete( url, headers=headers, data=payload,impersonate="chrome110")
+    response = requests.delete( url, headers=headers, data=payload,impersonate="chrome110", proxies=self.proxies)
 
     # Returns True if deleted or False if any error in deleting
     if response.status_code == 204:
@@ -181,8 +187,8 @@ class Client:
         'Cookie': f'{self.cookie}'
     }
 
-    response = requests.get( url, headers=headers,impersonate="chrome110")
-    
+    response = requests.get( url, headers=headers,impersonate="chrome110", proxies=self.proxies)
+
 
     # List all the conversations in JSON
     return response.json()
@@ -214,7 +220,7 @@ class Client:
         'TE': 'trailers'
     }
 
-    response = requests.post( url, headers=headers, data=payload,impersonate="chrome110")
+    response = requests.post( url, headers=headers, data=payload,impersonate="chrome110", proxies=self.proxies)
 
     # Returns JSON of the newly created conversation information
     return response.json()
@@ -271,9 +277,9 @@ class Client:
       return response.json()
     else:
       return False
-      
 
-    
+
+
   # Renames the chat conversation title
   def rename_chat(self, title, conversation_id):
     url = "https://claude.ai/api/rename_chat"
@@ -298,10 +304,10 @@ class Client:
         'TE': 'trailers'
     }
 
-    response = requests.post(url, headers=headers, data=payload,impersonate="chrome110")
+    response = requests.post(url, headers=headers, data=payload,impersonate="chrome110", proxies=self.proxies)
 
     if response.status_code == 200:
       return True
     else:
       return False
-      
+


### PR DESCRIPTION
### Purpose
Add proxy setting to the Claude client, the user may has no right to connect claude.ai direct directly, but can do by a proxy. So this PR add an optional parameter to __init__ funtion of Client class, which expect a dict to specify proxies for all protocals. The format of proxy parametr is same as [requests lib](https://requests.readthedocs.io/en/latest/api/).

### Usage
```
import json
import os

from claude_api import Client

cookie = os.environ.get('cookie')
if not cookie:
    raise Exception('Please set the cookie environment variable')
print(f'cookie:{cookie}')

claude_api = Client(cookie, proxies={
   'http': 'http://proxy.example.com:8080',
   'https': 'http://secureproxy.example.com:8090',
})

prompt = "Please give me an interesting python code snippet within 5 lines."
conversation = claude_api.create_new_chat()
conversation_id = conversation['uuid']

response = claude_api.send_message(prompt, conversation_id)
print(response)
```