### PR TITLE
Feat: add supports for stream mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,29 +86,34 @@ To list all the conversation Id's you had with Claude , you can use the list_all
         conversation_id = conversation['uuid']
         print(conversation_id)
 
-## Send Message
+## Query
 
-To send a message to Claude, you can use the send_message method. You need to provide the prompt and the conversation ID:
-
-
+To query Claude, you can use the query method. You need to provide the prompt and the conversation ID:
 
     prompt = "Hello, Claude!"
     conversation_id = "<conversation_id>" or claude_api.create_new_chat()['uuid']
-    response = claude_api.send_message(prompt, conversation_id)
+    response = claude_api.query(prompt, conversation_id)
     print(response)
 
-## Send Message with attachment
+Also supported stream mode:
 
-You can send any type of attachment to claude to get responses using attachment argument in send_message().
+    prompt = "Hello, Claude!"
+    conversation_id = "<conversation_id>" or claude_api.create_new_chat()['uuid']
+    response = claude_api.query(prompt, conversation_id, stream=True)
+    for r in response:
+        print(r, end="")
+
+## Query with attachment
+
+You can send any type of attachment to claude to get responses using attachment argument in query().
 Note: Claude currently supports only some file types.
 
 { You can also add timeout if you need ,using timeout parameter[default set to 500] }
 
     prompt = "Hey,Summarize me this document.!"
     conversation_id = "<conversation_id>" or claude_api.create_new_chat()['uuid']
-    response = claude_api.send_message(prompt, conversation_id,attachment="path/to/file.pdf",timeout=600)
+    response = claude_api.query(prompt, conversation_id,attachment="path/to/file.pdf",timeout=600)
     print(response)
-
 
 ## Delete Conversation
 

--- a/claude-api/claude_api.py
+++ b/claude-api/claude_api.py
@@ -76,65 +76,12 @@ class Client:
 
   # Send Message to Claude
   def send_message(self, prompt, conversation_id, attachment=None,timeout=500):
-    url = "https://claude.ai/api/append_message"
-
-    # Upload attachment if provided
-    attachments = []
-    if attachment:
-      attachment_response = self.upload_attachment(attachment)
-      if attachment_response:
-        attachments = [attachment_response]
-      else:
-        return {"Error: Invalid file format. Please try again."}
-
-    # Ensure attachments is an empty list when no attachment is provided
-    if not attachment:
-      attachments = []
-
-    payload = json.dumps({
-      "completion": {
-        "prompt": f"{prompt}",
-        "timezone": "Asia/Kolkata",
-        "model": "claude-2"
-      },
-      "organization_uuid": f"{self.organization_id}",
-      "conversation_uuid": f"{conversation_id}",
-      "text": f"{prompt}",
-      "attachments": attachments
-    })
-
-    headers = {
-      'User-Agent':
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0',
-      'Accept': 'text/event-stream, text/event-stream',
-      'Accept-Language': 'en-US,en;q=0.5',
-      'Referer': 'https://claude.ai/chats',
-      'Content-Type': 'application/json',
-      'Origin': 'https://claude.ai',
-      'DNT': '1',
-      'Connection': 'keep-alive',
-      'Cookie': f'{self.cookie}',
-      'Sec-Fetch-Dest': 'empty',
-      'Sec-Fetch-Mode': 'cors',
-      'Sec-Fetch-Site': 'same-origin',
-      'TE': 'trailers'
-    }
-
-    response = requests.post( url, headers=headers, data=payload,impersonate="chrome110",timeout=500)
-    decoded_data = response.content.decode("utf-8")
-    decoded_data = re.sub('\n+', '\n', decoded_data).strip()
-    data_strings = decoded_data.split('\n')
-    completions = []
-    for data_string in data_strings:
-      json_str = data_string[6:].strip()
-      data = json.loads(json_str)
-      if 'completion' in data:
-        completions.append(data['completion'])
-
-    answer = ''.join(completions)
-
-    # Returns answer
-    return answer
+    return self._non_stream_query(
+      prompt=prompt,
+      conversation_id=conversation_id,
+      attachment=attachment,
+      timeout=timeout,
+    )
   
   def _query_stream(
     self,


### PR DESCRIPTION
## Changes

- Add `query` method to wrap both stream and non-stream requests
- Make `send_message` a wrapper of non-stream mode request method
- Modified README

## Related Issues

- #58 
- #23 
- #76 
- #68 

## Test Case

```python
from claude_api import Client

cookie_str = "fill cookie here"

claude = Client(cookie_str)

conversation_id = claude.create_new_chat()['uuid']

stream = False

gen = claude.query(
    prompt="What is the meaning of life?",
    conversation_id=conversation_id,
    stream=stream,
)

import time

if stream:
    for msg in gen:
        print(time.time(), msg)
        
else:
    print(gen)
```