### PR TITLE
fix: change the model's name of claude

### DIFF
--- a/claude-api/claude_api.py
+++ b/claude-api/claude_api.py
@@ -94,7 +94,7 @@ class Client:
       "completion": {
         "prompt": f"{prompt}",
         "timezone": "Asia/Kolkata",
-        "model": "claude-2"
+        "model": "claude-2.0"
       },
       "organization_uuid": f"{self.organization_id}",
       "conversation_uuid": f"{conversation_id}",


### PR DESCRIPTION
Hi, I found that recently Claude has changed their model's name from `claude-2` to `claude-2.0`. The change will result in some errors:
```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

r":{"type":"permission_error","message":"Invalid model","code":"model_not_allowed"}}
```
After I change the name of model, it works again.
